### PR TITLE
Add Azure Linux 2.0 aarch64

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -342,7 +342,7 @@ extractor = kconfigs.rpm.RpmExtractor
 index = https://mirror.stream.centos.org/SIGs/9-stream/hyperscale/aarch64/packages-experimental/
 key = RPM-GPG-KEY-CentOS-SIG-HyperScale
 
-## Azure Linux
+## Azure Linux x86_64
 
 [cm2_x86_64]
 name = Azure Linux
@@ -352,6 +352,18 @@ package = kernel
 fetcher = kconfigs.rpm.RpmFetcher
 extractor = kconfigs.rpm.RpmExtractor
 index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/
+key = azurelinux
+
+## Azure Linux aarch64
+
+[cm2_aarch64]
+name = Azure Linux
+version = 2
+arch = aarch64
+package = kernel
+fetcher = kconfigs.rpm.RpmFetcher
+extractor = kconfigs.rpm.RpmExtractor
+index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/aarch64/
 key = azurelinux
 
 ## Ubuntu x86_64


### PR DESCRIPTION
Azure Linux (previously known as CBL-Mariner) is an internal Linux
distribution for Microsoft's cloud infrastructure and edge products
and services. It is an RPM-based distribution.

https://github.com/microsoft/azurelinux

Azure Linux 2.0 aarch64 packages are hosted on
https://packages.microsoft.com/cbl-mariner/2.0/prod/base/aarch64/

The GPG key verification has already been handled in #1 

An entry for Azure Linux 2.0 aarch64 is added in the config.ini
so the kernel config data can be extracted and incorporated into the
database.

Signed-off-by: Ankita Pareek [ankitapareek@microsoft.com](mailto:ankitapareek@microsoft.com)