### PR TITLE
Add Azure Linux 3.0 preview for x86_64 and aarch64

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -355,7 +355,7 @@ index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/
 key = azurelinux
 
 [azl3_preview_x86_64]
-name = Azure Linux
+name = Azure Linux Preview
 version = 3
 arch = x86_64
 package = kernel
@@ -377,7 +377,7 @@ index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/aarch64/
 key = azurelinux
 
 [azl3_preview_aarch64]
-name = Azure Linux
+name = Azure Linux Preview
 version = 3
 arch = aarch64
 package = kernel

--- a/config.ini
+++ b/config.ini
@@ -354,6 +354,16 @@ extractor = kconfigs.rpm.RpmExtractor
 index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/
 key = azurelinux
 
+[azl3_preview_x86_64]
+name = Azure Linux
+version = 3
+arch = x86_64
+package = kernel
+fetcher = kconfigs.rpm.RpmFetcher
+extractor = kconfigs.rpm.RpmExtractor
+index = https://packages.microsoft.com/azurelinux/3.0/preview/base/x86_64/
+key = azurelinux
+
 ## Azure Linux aarch64
 
 [cm2_aarch64]
@@ -364,6 +374,16 @@ package = kernel
 fetcher = kconfigs.rpm.RpmFetcher
 extractor = kconfigs.rpm.RpmExtractor
 index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/aarch64/
+key = azurelinux
+
+[azl3_preview_aarch64]
+name = Azure Linux
+version = 3
+arch = aarch64
+package = kernel
+fetcher = kconfigs.rpm.RpmFetcher
+extractor = kconfigs.rpm.RpmExtractor
+index = https://packages.microsoft.com/azurelinux/3.0/preview/base/aarch64/
 key = azurelinux
 
 ## Ubuntu x86_64


### PR DESCRIPTION
Azure Linux (previously known as CBL-Mariner) is an internal Linux distribution for Microsoft's cloud infrastructure and edge products and services. It is an RPM-based distribution.

https://github.com/microsoft/azurelinux

Azure Linux 3.0 preview packages are hosted as follows:
- For x86_64 - https://packages.microsoft.com/azurelinux/3.0/preview/base/x86_64/
- For aarch64 - https://packages.microsoft.com/azurelinux/3.0/preview/base/aarch64/

Azure Linux 3.0 preview uses the following GPG keys -
- azurelinux-metadata-key
   - https://github.com/microsoft/azurelinux/blob/3.0-dev/SPECS/azurelinux-repos/MICROSOFT-METADATA-GPG-KEY
   - This public key can be used to verify the repomd.xml.asc signature for the repomd.xml
- azurelinux-rpm-key
   - https://github.com/microsoft/azurelinux/blob/3.0-dev/SPECS/azurelinux-repos/MICROSOFT-RPM-GPG-KEY
   - This public key can be used to verify the krnel RPM signature itself

These keys are same as those used for verification in Azure Linux 2.0

Entries for Azure Linux 3.0 preview are added in config.ini for both x86_64 and aarch64 architectures. This enables the kernel config data to be extracted and incorporated into the database.

Signed-off-by: Ankita Pareek [ankitapareek@microsoft.com](mailto:ankitapareek@microsoft.com)