### PR TITLE
Add Azure Linux 2.0 MOS, HCI, and MSHV kernels

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -354,6 +354,36 @@ extractor = kconfigs.rpm.RpmExtractor
 index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/
 key = azurelinux
 
+[cm2_mos_x86_64]
+name = Azure Linux MOS
+version = 2
+arch = x86_64
+package = kernel-mos
+fetcher = kconfigs.rpm.RpmFetcher
+extractor = kconfigs.rpm.RpmExtractor
+index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/
+key = azurelinux
+
+[cm2_hci_x86_64]
+name = Azure Linux HCI
+version = 2
+arch = x86_64
+package = kernel-hci
+fetcher = kconfigs.rpm.RpmFetcher
+extractor = kconfigs.rpm.RpmExtractor
+index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/
+key = azurelinux
+
+[cm2_mshv_x86_64]
+name = Azure Linux MSHV
+version = 2
+arch = x86_64
+package = kernel
+fetcher = kconfigs.rpm.RpmFetcher
+extractor = kconfigs.rpm.RpmExtractor
+index = https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64/
+key = azurelinux
+
 [azl3_preview_x86_64]
 name = Azure Linux Preview
 version = 3


### PR DESCRIPTION
Azure Linux 2.0 also supplies kernel variants to meet specific product or services requirements. Include these kernels into the database.

Signed-off-by: Chris Co <christopher.co@microsoft.com>