### PR TITLE
Add devcontainer to create GitHub Codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/python:3.11
+# Install Dependencies
+RUN apt-get update && apt-get install -y gzip bzip2 xz-utils zstd tar rpm cpio dpkg make pre-commit
+ENV GNUPGHOME=/tmp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "name": "Python",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "onCreateCommand": ".devcontainer/onCreateCommand.sh"
+}

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+make dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ can be accepted.
 
 ### Development Environment
 
+#### Using GitHub Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/christopherco/kconfigs)
+
+#### Using Your Local System
 Follow the "How to Run" section of the README first. Then, you can install
 additional development dependencies:
 


### PR DESCRIPTION
GitHub Codespaces is a way to quickly create a development environment
that is hosted in the cloud.

This change adds a dev container definition to create an initial python
3.11 environment, install dependencies, and set up the project's dev
environment including the pre-commit hooks.

Signed-off-by: Chris Co <christopher.co@microsoft.com>